### PR TITLE
Fix ident() definition

### DIFF
--- a/src/leader_cron.erl
+++ b/src/leader_cron.erl
@@ -71,7 +71,7 @@
 -define(SERVER, ?MODULE).
 
 %% The task pid() or name.
--type ident() :: {atom() | pid()}.
+-type ident() :: atom() | pid().
 
 -type task() :: {ident(),
                  leader_cron_task:schedule(),


### PR DESCRIPTION
Mistakenly put atom() | pid() inside a tuple.
