### PR TITLE
Fixing max sleep method.

### DIFF
--- a/src/leader_cron.app.src
+++ b/src/leader_cron.app.src
@@ -1,7 +1,7 @@
 {application, leader_cron,
  [
   {description, ""},
-  {vsn, "0.2"},
+  {vsn, "0.2.1"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
Erlang has a max value that may be passed to timer:sleep().

I've created a new function to trap for this condition and sleep in
periods below the max until the time is hit.